### PR TITLE
Update values to MongoDB to get it deployable

### DIFF
--- a/mongodb/values.yml
+++ b/mongodb/values.yml
@@ -1,5 +1,8 @@
-usePassword: true
-mongodbRootPassword: okteto
-mongodbUsername: okteto
-mongodbPassword: okteto
-mongodbDatabase: okteto
+persistence:
+  size: 1Gi
+
+auth:
+  enabled: true
+  database: okteto
+  password: okteto
+  username: okteto

--- a/okteto.yml
+++ b/okteto.yml
@@ -10,7 +10,7 @@ deploy:
   - name: Install Bitnami Charts
     command: helm repo add bitnami https://charts.bitnami.com/bitnami
   - name: Deploy MongoDB
-    command:  helm upgrade --install mongodb bitnami/mongodb -f mongodb/values.yml --version 7.2.11
+    command:  helm upgrade --install mongodb bitnami/mongodb -f mongodb/values.yml --version 12.1.15
   - name: Deploy API
     command: helm upgrade --install movies-api chart --set image=${OKTETO_BUILD_API_IMAGE}
 


### PR DESCRIPTION
Was talking to DT about this a couple days ago. 

Just some updates:
- Use newer version of `bitnami/mongodb`, 7.2.11 -> 12.1.15
- Update `mongodb/values` 
  - add persistence of 1Gi (defaults to 8Gi which is too large for free accounts)
  - edit mongodb db/user/pass to use newer schema

These values should reflect what is in okteto/movies repo.